### PR TITLE
Improve evaluation and run all algorithms

### DIFF
--- a/src/classes/_Agent.py
+++ b/src/classes/_Agent.py
@@ -244,7 +244,7 @@ class Agent:
         logger.info(f"Replay buffer salvo em {final_replay_path}")
         return model, final_replay_path
 
-    def env3W_dqn_eval(self, model: Any, path_save: str, n_eval_episodes: int = 1) -> float:
+    def env3W_dqn_eval(self, model: Any, path_save: str, n_eval_episodes: int = 5) -> float:
         logger.info(f"Avaliando o modelo DQN em {path_save} com {n_eval_episodes} episódios.")
         return self._evaluate_model(model, n_eval_episodes, "DQN")
 
@@ -274,7 +274,7 @@ class Agent:
         logger.info(f"Modelo final salvo em {final_model_path}")
         return model
 
-    def env3W_ppo_eval(self, model: Any, path_save: str, n_eval_episodes: int = 1) -> float:
+    def env3W_ppo_eval(self, model: Any, path_save: str, n_eval_episodes: int = 5) -> float:
         logger.info(f"Avaliando o modelo PPO em {path_save} com {n_eval_episodes} episódios.")
         return self._evaluate_model(model, n_eval_episodes, "PPO")
 
@@ -285,11 +285,11 @@ class Agent:
         metrics_callback = MetricsCSVCallback(save_path=final_model_path, verbose=0)
         model.learn(total_timesteps=self.TIMESTEPS, progress_bar=True, reset_num_timesteps=True, tb_log_name="A2C", 
                     callback=[metrics_callback])
-        model.save(os.path.join(path_save, 'A2C'))
-        logger.info(f"Modelo final salvo em {os.path.join(path_save, '_A2C')}")
+        model.save(final_model_path)
+        logger.info(f"Modelo final salvo em {final_model_path}")
         return model
 
-    def env3W_a2c_eval(self, model: Any, path_save: str, n_eval_episodes: int = 1) -> float:
+    def env3W_a2c_eval(self, model: Any, path_save: str, n_eval_episodes: int = 5) -> float:
         logger.info(f"Avaliando o modelo A2C em {path_save} com {n_eval_episodes} episódios.")
         return self._evaluate_model(model, n_eval_episodes, "A2C")
 

--- a/src/train_pipeline.py
+++ b/src/train_pipeline.py
@@ -72,7 +72,8 @@ def train_evaluate_model(
     supervised: Optional[Supervised] = None,
     dataset_train: Optional[np.ndarray] = None,
     dataset_test: Optional[np.ndarray] = None,
-    if_params: Optional[Dict[str, Any]] = None
+    if_params: Optional[Dict[str, Any]] = None,
+    n_eval_episodes: int = 5,
 ) -> Optional[Dict[str, Any]]:
     """Treina e avalia um modelo, retornando dicionário de resultados."""
     agente.TIMESTEPS = ts
@@ -105,11 +106,11 @@ def train_evaluate_model(
     start = time.time()
     try:
         if model_type == "DQN":
-            accuracy = agente.env3W_dqn_eval(model=model_agent, path_save=path_model)
+            accuracy = agente.env3W_dqn_eval(model=model_agent, path_save=path_model, n_eval_episodes=n_eval_episodes)
         elif model_type == "PPO":
-            accuracy = agente.env3W_ppo_eval(model=model_agent, path_save=path_model)
+            accuracy = agente.env3W_ppo_eval(model=model_agent, path_save=path_model, n_eval_episodes=n_eval_episodes)
         elif model_type == "A2C":
-            accuracy = agente.env3W_a2c_eval(model=model_agent, path_save=path_model)
+            accuracy = agente.env3W_a2c_eval(model=model_agent, path_save=path_model, n_eval_episodes=n_eval_episodes)
         elif model_type == "RNA" and supervised is not None:
             accuracy = supervised.keras_evaluate(model_agent)
         elif model_type == "IF":
@@ -226,7 +227,7 @@ def run_event(
 
 def main() -> None:
     events_names = {1: "Abrupt Increase of BSW"}
-    models = ["IF"]
+    models = ["DQN", "PPO", "A2C", "RNA", "IF"]
     type_instance = "real"
 
     # grid de hiperparâmetros para IF


### PR DESCRIPTION
## Summary
- increase default evaluation episodes in `_Agent.py`
- save the A2C model to the intended path
- allow `train_evaluate_model` to pass evaluation episode count
- execute every available algorithm by default

## Testing
- `python -m py_compile src/classes/_Agent.py src/train_pipeline.py`

------
https://chatgpt.com/codex/tasks/task_e_68544e325680832e8365af6d193e48b1